### PR TITLE
Add cookie secure flag.

### DIFF
--- a/auth/logout_handler_test.go
+++ b/auth/logout_handler_test.go
@@ -44,6 +44,7 @@ var _ = Describe("LogOutHandler", func() {
 				fakeAuthTokenGenerator,
 				expire,
 				false,
+				false,
 			)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/auth/oauth_begin_handler.go
+++ b/auth/oauth_begin_handler.go
@@ -26,6 +26,7 @@ type OAuthBeginHandler struct {
 	providerFactory ProviderFactory
 	teamFactory     db.TeamFactory
 	expire          time.Duration
+	cookieSecure    bool
 	isTLSEnabled    bool
 }
 
@@ -34,6 +35,7 @@ func NewOAuthBeginHandler(
 	providerFactory ProviderFactory,
 	teamFactory db.TeamFactory,
 	expire time.Duration,
+	cookieSecure bool,
 	isTLSEnabled bool,
 ) http.Handler {
 	return &OAuthBeginHandler{
@@ -41,6 +43,7 @@ func NewOAuthBeginHandler(
 		providerFactory: providerFactory,
 		teamFactory:     teamFactory,
 		expire:          expire,
+		cookieSecure:    cookieSecure,
 		isTLSEnabled:    isTLSEnabled,
 	}
 }
@@ -126,7 +129,7 @@ func (handler *OAuthBeginHandler) ServeHTTP(w http.ResponseWriter, r *http.Reque
 		Expires:  time.Now().Add(handler.expire),
 		HttpOnly: true,
 	}
-	if handler.isTLSEnabled {
+	if handler.cookieSecure || handler.isTLSEnabled {
 		authCookie.Secure = true
 	}
 	// TODO: Add SameSite once Golang supports it

--- a/auth/oauth_begin_handler.go
+++ b/auth/oauth_begin_handler.go
@@ -4,11 +4,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/concourse/atc/db"
-
-	"strconv"
 
 	"code.cloudfoundry.org/lager"
 )

--- a/auth/oauth_begin_handler_test.go
+++ b/auth/oauth_begin_handler_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
 	"net/http/httptest"
@@ -14,7 +13,7 @@ import (
 	"code.cloudfoundry.org/lager/lagertest"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/ghttp"
+	. "github.com/onsi/gomega/gstruct"
 
 	"github.com/concourse/atc/db/dbfakes"
 	"github.com/concourse/skymarshal/auth"
@@ -39,6 +38,9 @@ var _ = Describe("OAuthBeginHandler", func() {
 
 		server *httptest.Server
 		client *http.Client
+
+		cookieSecure bool
+		isTLSEnabled bool
 	)
 
 	BeforeEach(func() {
@@ -53,6 +55,22 @@ var _ = Describe("OAuthBeginHandler", func() {
 
 		expire = 24 * time.Hour
 
+		var err error
+		cookieJar, err = cookiejar.New(nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		client = &http.Client{
+			Transport: &http.Transport{},
+			Jar:       cookieJar,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+
+		fakeProviderFactory.GetProviderReturns(fakeProvider, true, nil)
+	})
+
+	JustBeforeEach(func() {
 		handler, err := auth.NewOAuthHandler(
 			lagertest.NewTestLogger("test"),
 			fakeProviderFactory,
@@ -60,46 +78,32 @@ var _ = Describe("OAuthBeginHandler", func() {
 			fakeCSRFTokenGenerator,
 			fakeAuthTokenGenerator,
 			expire,
-			false,
-			false,
+			cookieSecure,
+			isTLSEnabled,
 		)
 		Expect(err).ToNot(HaveOccurred())
 
 		server = httptest.NewServer(handler)
-
-		cookieJar, err = cookiejar.New(nil)
-		Expect(err).ToNot(HaveOccurred())
-
-		client = &http.Client{
-			Transport: &http.Transport{},
-			Jar:       cookieJar,
-		}
-
-		fakeProviderFactory.GetProviderReturns(fakeProvider, true, nil)
 	})
 
 	Describe("GET /auth/:provider/teams/:team_name", func() {
-		var redirectTarget *ghttp.Server
-		var request *http.Request
-		var response *http.Response
+		var (
+			request  *http.Request
+			response *http.Response
+			path     string
+		)
 
-		BeforeEach(func() {
-			redirectTarget = ghttp.NewServer()
-			redirectTarget.RouteToHandler("GET", "/", ghttp.RespondWith(http.StatusOK, "sup"))
-
+		JustBeforeEach(func() {
 			var err error
 
 			request, err = http.NewRequest("GET", server.URL, nil)
 			Expect(err).NotTo(HaveOccurred())
 
+			request.URL.Path = path
 			request.URL.RawQuery = url.Values{
 				"redirect":  {"/some-path"},
 				"team_name": {"some-team"},
 			}.Encode()
-		})
-
-		JustBeforeEach(func() {
-			var err error
 
 			response, err = client.Do(request)
 			Expect(err).NotTo(HaveOccurred())
@@ -113,13 +117,13 @@ var _ = Describe("OAuthBeginHandler", func() {
 
 			Context("to a known provider", func() {
 				BeforeEach(func() {
-					request.URL.Path = "/auth/provider-name"
-					fakeProvider.AuthCodeURLReturns(redirectTarget.URL(), nil)
+					path = "/auth/provider-name"
+					fakeProvider.AuthCodeURLReturns("http://provider.com/redirect", nil)
 				})
 
 				It("redirects to the auth code URL", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusOK))
-					Expect(ioutil.ReadAll(response.Body)).To(Equal([]byte("sup")))
+					Expect(response.StatusCode).To(Equal(http.StatusTemporaryRedirect))
+					Expect(response.Header.Get("Location")).To(Equal("http://provider.com/redirect"))
 				})
 
 				It("generates the auth code with a base64-encoded redirect URI and team name as the state", func() {
@@ -150,22 +154,51 @@ var _ = Describe("OAuthBeginHandler", func() {
 						Value: state,
 					}))
 				})
+
+				Context("with secure cookies", func() {
+					BeforeEach(func() {
+						cookieSecure = true
+						isTLSEnabled = false
+					})
+
+					It("sets the cookie secure flag", func() {
+						Expect(response.Cookies()).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Name":   Equal(auth.OAuthStateCookie),
+							"Secure": BeTrue(),
+						}))))
+					})
+				})
+
+				Context("with tls enabled", func() {
+					BeforeEach(func() {
+						cookieSecure = false
+						isTLSEnabled = true
+					})
+
+					It("sets the cookie secure flag", func() {
+						Expect(response.Cookies()).To(ContainElement(PointTo(MatchFields(IgnoreExtras, Fields{
+							"Name":   Equal(auth.OAuthStateCookie),
+							"Secure": BeTrue(),
+						}))))
+					})
+				})
 			})
 
 			Context("to an unknown provider", func() {
 				BeforeEach(func() {
-					request.URL.Path = "/auth/bogus"
+					path = "/auth/bogus"
 				})
 
-				It("returns 404 not found", func() {
-					Expect(response.StatusCode).To(Equal(http.StatusNotFound))
+				It("redirects to /auth/", func() {
+					Expect(response.StatusCode).To(Equal(http.StatusTemporaryRedirect))
+					Expect(response.Header.Get("Location")).To(Equal("/auth/"))
 				})
 			})
 		})
 
 		Context("when the team doesn't exist", func() {
 			BeforeEach(func() {
-				request.URL.Path = "/auth/b"
+				path = "/auth/b"
 
 				fakeTeamFactory.FindTeamReturns(fakeTeam, false, nil)
 			})
@@ -178,7 +211,7 @@ var _ = Describe("OAuthBeginHandler", func() {
 		Context("when looking up the team fails", func() {
 			var disaster error
 			BeforeEach(func() {
-				request.URL.Path = "/auth/b"
+				path = "/auth/b"
 
 				disaster = errors.New("out of service")
 				fakeTeamFactory.FindTeamReturns(fakeTeam, false, disaster)

--- a/auth/oauth_begin_handler_test.go
+++ b/auth/oauth_begin_handler_test.go
@@ -61,6 +61,7 @@ var _ = Describe("OAuthBeginHandler", func() {
 			fakeAuthTokenGenerator,
 			expire,
 			false,
+			false,
 		)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/auth/oauth_callback_handler.go
+++ b/auth/oauth_callback_handler.go
@@ -28,6 +28,7 @@ type OAuthCallbackHandler struct {
 	csrfTokenGenerator CSRFTokenGenerator
 	authTokenGenerator AuthTokenGenerator
 	expire             time.Duration
+	cookieSecure       bool
 	isTLSEnabled       bool
 	stateValidator     oauthStateValidator
 }
@@ -39,6 +40,7 @@ func NewOAuthCallbackHandler(
 	csrfTokenGenerator CSRFTokenGenerator,
 	authTokenGenerator AuthTokenGenerator,
 	expire time.Duration,
+	cookieSecure bool,
 	isTLSEnabled bool,
 	stateValidator oauthStateValidator,
 ) http.Handler {
@@ -49,6 +51,7 @@ func NewOAuthCallbackHandler(
 		csrfTokenGenerator: csrfTokenGenerator,
 		authTokenGenerator: authTokenGenerator,
 		expire:             expire,
+		cookieSecure:       cookieSecure,
 		isTLSEnabled:       isTLSEnabled,
 		stateValidator:     stateValidator,
 	}
@@ -198,7 +201,7 @@ func (handler *OAuthCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Re
 		Expires:  exp,
 		HttpOnly: true,
 	}
-	if handler.isTLSEnabled {
+	if handler.cookieSecure || handler.isTLSEnabled {
 		authCookie.Secure = true
 	}
 	// TODO: Add SameSite once Golang supports it

--- a/auth/oauth_callback_handler_test.go
+++ b/auth/oauth_callback_handler_test.go
@@ -102,6 +102,7 @@ var _ = Describe("OAuthCallbackHandler", func() {
 			fakeAuthTokenGenerator,
 			expire,
 			false,
+			false,
 		)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/auth/oauth_handler.go
+++ b/auth/oauth_handler.go
@@ -26,6 +26,7 @@ func NewOAuthHandler(
 	csrfTokenGenerator CSRFTokenGenerator,
 	authTokenGenerator AuthTokenGenerator,
 	expire time.Duration,
+	cookieSecure bool,
 	isTLSEnabled bool,
 ) (http.Handler, error) {
 	return rata.NewRouter(
@@ -36,6 +37,7 @@ func NewOAuthHandler(
 				providerFactory,
 				teamFactory,
 				expire,
+				cookieSecure,
 				isTLSEnabled,
 			),
 			OAuthCallback: NewOAuthCallbackHandler(
@@ -45,6 +47,7 @@ func NewOAuthHandler(
 				csrfTokenGenerator,
 				authTokenGenerator,
 				expire,
+				cookieSecure,
 				isTLSEnabled,
 				oauthV2StateValidator{},
 			),
@@ -62,6 +65,7 @@ func NewOAuthV1Handler(
 	csrfTokenGenerator CSRFTokenGenerator,
 	authTokenGenerator AuthTokenGenerator,
 	expire time.Duration,
+	cookieSecure bool,
 	isTLSEnabled bool,
 ) (http.Handler, error) {
 	return rata.NewRouter(
@@ -72,6 +76,7 @@ func NewOAuthV1Handler(
 				providerFactory,
 				teamFactory,
 				expire,
+				cookieSecure,
 				isTLSEnabled,
 			),
 			OAuthV1Callback: NewOAuthCallbackHandler(
@@ -81,6 +86,7 @@ func NewOAuthV1Handler(
 				csrfTokenGenerator,
 				authTokenGenerator,
 				expire,
+				cookieSecure,
 				isTLSEnabled,
 				oauthV1StateValidator{},
 			),

--- a/authserver/get_auth_token.go
+++ b/authserver/get_auth_token.go
@@ -66,7 +66,7 @@ func (s *Server) generateToken(logger lager.Logger, w http.ResponseWriter, r *ht
 		Expires:  expiry,
 		HttpOnly: true,
 	}
-	if s.isTLSEnabled {
+	if s.cookieSecure || s.isTLSEnabled {
 		authCookie.Secure = true
 	}
 	// TODO: Add SameSite once Golang supports it

--- a/authserver/server.go
+++ b/authserver/server.go
@@ -13,6 +13,7 @@ type Server struct {
 	externalURL        string
 	oAuthBaseURL       string
 	expire             time.Duration
+	cookieSecure       bool
 	isTLSEnabled       bool
 	teamFactory        db.TeamFactory
 	providerFactory    auth.ProviderFactory
@@ -28,6 +29,7 @@ func NewServer(
 	externalURL string,
 	oAuthBaseURL string,
 	expire time.Duration,
+	cookieSecure bool,
 	isTLSEnabled bool,
 	teamFactory db.TeamFactory,
 	providerFactory auth.ProviderFactory,
@@ -43,6 +45,7 @@ func NewServer(
 		externalURL:        externalURL,
 		oAuthBaseURL:       oAuthBaseURL,
 		expire:             expire,
+		cookieSecure:       cookieSecure,
 		isTLSEnabled:       isTLSEnabled,
 		teamFactory:        teamFactory,
 		providerFactory:    providerFactory,

--- a/skymarshal.go
+++ b/skymarshal.go
@@ -16,6 +16,7 @@ type Config struct {
 	BaseAuthUrl  string
 	SigningKey   *rsa.PrivateKey
 	Expiration   time.Duration
+	CookieSecure bool
 	IsTLSEnabled bool
 	TeamFactory  db.TeamFactory
 	Logger       lager.Logger
@@ -25,6 +26,7 @@ type DetailedConfig struct {
 	BaseUrl            string
 	BaseAuthUrl        string
 	Expiration         time.Duration
+	CookieSecure       bool
 	IsTLSEnabled       bool
 	TeamFactory        db.TeamFactory
 	Logger             lager.Logger
@@ -59,6 +61,7 @@ func NewHandler(config *Config) (http.Handler, error) {
 		config.BaseUrl,
 		config.BaseAuthUrl,
 		config.Expiration,
+		config.CookieSecure,
 		config.IsTLSEnabled,
 		config.TeamFactory,
 		config.Logger,
@@ -81,6 +84,7 @@ func NewHandlerWithOptions(config *DetailedConfig) (http.Handler, error) {
 		config.CSRFTokenGenerator,
 		config.AuthTokenGenerator,
 		config.Expiration,
+		config.CookieSecure,
 		config.IsTLSEnabled,
 	)
 	if err != nil {
@@ -94,6 +98,7 @@ func NewHandlerWithOptions(config *DetailedConfig) (http.Handler, error) {
 		config.CSRFTokenGenerator,
 		config.AuthTokenGenerator,
 		config.Expiration,
+		config.CookieSecure,
 		config.IsTLSEnabled,
 	)
 	if err != nil {
@@ -105,6 +110,7 @@ func NewHandlerWithOptions(config *DetailedConfig) (http.Handler, error) {
 		config.BaseUrl,
 		config.BaseAuthUrl,
 		config.Expiration,
+		config.CookieSecure,
 		config.IsTLSEnabled,
 		config.TeamFactory,
 		config.OAuthFactory,


### PR DESCRIPTION
At the moment, skymarshal sets the `secure` cookie flag if the atc is terminating tls connections. But operators may terminate tls at a proxy in front of the atc, like elb, nginx, etc. In this case, operators should still be able to set `secure` on cookies. This patch adds a `CookieSecure` flag that forces secure cookies.

cc @wjwoodson