### PR TITLE
Accept client secret from flags.

### DIFF
--- a/skycmd/flags.go
+++ b/skycmd/flags.go
@@ -41,6 +41,7 @@ type AuthFlags struct {
 	Expiration    time.Duration     `long:"auth-duration" default:"24h" description:"Length of time for which tokens are valid. Afterwards, users will have to log back in."`
 	SigningKey    *flag.PrivateKey  `long:"session-signing-key" description:"File containing an RSA private key, used to sign auth tokens."`
 	LocalUsers    map[string]string `long:"add-local-user" description:"List of username:bcrypted_password combinations for all your local concourse users." value-name:"USERNAME:BCRYPTED_PASSWORD"`
+	ClientSecret  string            `long:"client-secret" description:"Client secret." required:"true"`
 }
 
 type AuthTeamFlags struct {

--- a/skymarshal.go
+++ b/skymarshal.go
@@ -34,9 +34,8 @@ func (self *Server) PublicKey() *rsa.PublicKey {
 }
 
 func NewServer(config *Config) (*Server, error) {
-
 	clientId := "skymarshal"
-	clientSecret := token.RandomString()
+	clientSecret := config.ClientSecret
 
 	signingKey, err := loadOrGenerateSigningKey(config.Flags.SigningKey)
 	if err != nil {


### PR DESCRIPTION
Instead of generating a random client secret on start, accept a static
client secret from flags. This allows multiple ATC instances to share a
dex client secret to avoid `invalid_client` errors when subsequent
requests go to different instances.

See https://github.com/concourse/concourse/issues/2425 and
https://github.com/concourse/concourse/issues/2483.